### PR TITLE
add dataclasses for structural materials

### DIFF
--- a/src/openpile/materials.py
+++ b/src/openpile/materials.py
@@ -1,0 +1,50 @@
+from enum import Enum
+
+from pydantic.dataclasses import dataclass
+
+
+class ConstitutiveModel:
+    pass
+
+
+class StructuralMaterial(ConstitutiveModel):
+    pass
+
+
+class StructuralMaterialEnum(str, Enum):
+    Steel = "Steel"
+    Concrete = "Concrete"
+    
+
+@dataclass
+class Steel(StructuralMaterial):
+    """
+    Parameters
+    ----------
+    uw: float = 78.0
+        Unit weight (kN/m3).
+    young_modulus: float = 210.0e6
+        Young modulus (kPa).
+    nu: float = 0.3
+        Poisson's ratio.
+    """
+    uw: float = 78.0
+    young_modulus: float = 210.0e6
+    nu: float = 0.3
+
+
+@dataclass
+class Concrete(StructuralMaterial):
+    """
+    Parameters
+    ----------
+    uw: float = 24.0
+        Unit weight (kN/m3).
+    young_modulus: float = 30.0e6
+        Young modulus (kPa).
+    nu: float = 0.2
+        Poisson's ratio.
+    """
+    uw: float = 24.0
+    young_modulus: float = 30.0e6
+    nu: float = 0.2

--- a/src/openpile/soilmodels.py
+++ b/src/openpile/soilmodels.py
@@ -32,18 +32,15 @@ from pydantic.dataclasses import dataclass
 from openpile.core.misc import from_list2x_parse_top_bottom, var_to_str, get_value_at_current_depth
 from openpile.utils import py_curves, Hb_curves, mt_curves, Mb_curves, tz_curves
 from openpile.utils.misc import _fmax_api_sand, _fmax_api_clay, _Qmax_api_clay, _Qmax_api_sand
+from openpile.materials import ConstitutiveModel
 
 
-# CONSTITUTIVE MODELS CLASSES ---------------------------------
+# SOIL CONSTITUTIVE MODELS CLASSES ---------------------------------
 
 
 class PydanticConfigFrozen:
     arbitrary_types_allowed = True
     allow_mutation = False
-
-
-class ConstitutiveModel:
-    pass
 
 
 class LateralModel(ConstitutiveModel):

--- a/test/test_construct.py
+++ b/test/test_construct.py
@@ -1,5 +1,7 @@
 from openpile import construct
 from openpile.soilmodels import API_clay
+from openpile.materials import Steel, Concrete
+
 import pytest
 import numpy as np
 import math as m
@@ -105,6 +107,62 @@ class TestPile:
         )
 
         assert m.isclose(pile.area.mean(), m.pi * 0.001, rel_tol=0.01)
+
+    def test_concrete_pile(self):
+        pile = construct.Pile(
+            name="",
+            kind="Circular",
+            material="Concrete",
+            top_elevation=0,
+            pile_sections={
+                "length": [20],
+                "diameter": [1.0],
+                "wall thickness": [0.5],
+            },
+        )
+
+        assert m.isclose(pile.area.mean(), m.pi / 4, rel_tol=0.01)
+        assert isinstance(pile.material, Concrete)
+        assert m.isclose(pile.material.uw, 24)
+        assert m.isclose(pile.material.young_modulus, 30e6)
+        assert m.isclose(pile.material.nu, 0.2)        
+
+    def test_steel_pile_material_obj(self):
+        pile = construct.Pile(
+            name="",
+            kind="Circular",
+            material=Steel(uw=77, young_modulus=200e6, nu=0.31),
+            top_elevation=0,
+            pile_sections={
+                "length": [20],
+                "diameter": [0.8],
+                "wall thickness": [0.08],
+            },
+        )
+
+        assert isinstance(pile.material, Steel)
+        assert m.isclose(pile.material.uw, 77)
+        assert m.isclose(pile.material.young_modulus, 200e6)
+        assert m.isclose(pile.material.nu, 0.31)
+
+    def test_concrete_pile_material_obj(self):
+        pile = construct.Pile(
+            name="",
+            kind="Circular",
+            material=Concrete(uw=25, young_modulus=28e6, nu=0.18),
+            top_elevation=0,
+            pile_sections={
+                "length": [20],
+                "diameter": [1.0],
+                "wall thickness": [0.5],
+            },
+        )
+
+        assert m.isclose(pile.area.mean(), m.pi / 4, rel_tol=0.01)
+        assert isinstance(pile.material, Concrete)
+        assert m.isclose(pile.material.uw, 25)
+        assert m.isclose(pile.material.young_modulus, 28e6)
+        assert m.isclose(pile.material.nu, 0.18)        
 
 
 class TestLayer:


### PR DESCRIPTION
Added dataclasses for structural materials so the properties can be easily customizable: Steel and Concrete.

Pile objects can be initialized with `material` as a string ('Steel', 'Concrete') or with the new dataclasses.