### PR TITLE
Franke rollins2013

### DIFF
--- a/src/openpile/construct.py
+++ b/src/openpile/construct.py
@@ -73,9 +73,9 @@ class Pile:
         argument that stores the relevant data of each pile segment.
         Below are the needed keys for the available piles:
         - kind:'Circular' >> keys:['length', 'diameter', 'wall thickness']
-    kind : Literal["Circular",]
+    kind : Literal["Circular", "Solid-Circle",]
         type of pile or type of cross-section. by default "Circular"
-    material : Literal["Steel",]
+    material : Literal["Steel", "Concrete",]
         material the pile is made of. by default "Steel"
 
 
@@ -99,9 +99,9 @@ class Pile:
     #: name of the pile
     name: str
     #: select the type of pile, can be of ('Circular', )
-    kind: Literal["Circular"]
+    kind: Literal["Circular", "Solid-Circle"]
     #: select the type of material the pile is made of, can be of ('Steel', )
-    material: Literal["Steel"]
+    material: Literal["Steel", "Concrete"]
     #: top elevation of the pile according to general vertical reference set by user
     top_elevation: float
     #: pile geometry made of a dictionary of lists. the structure of the dictionary depends on the type of pile selected.
@@ -121,6 +121,15 @@ class Pile:
             self._young_modulus = 210.0e6  # kPa
             # Poisson's ratio
             self._nu = 0.3
+                      
+        elif self.material == "Concrete":
+            # unit weight
+            self._uw = 22.78  # kN/m3 ~145lb/ft3
+            # young modulus
+            self._young_modulus = 24_870_062.324  # kPa ~4700*sqrt(f'c = 28 MPa)
+            # Poisson's ratio
+            self._nu = 0.15
+
         else:
             raise UserWarning
 
@@ -169,6 +178,15 @@ class Pile:
                 area.append(area[-1])
                 second_moment_of_area.append(I)
                 second_moment_of_area.append(second_moment_of_area[-1])
+            
+            elif self.kind == "Solid-Circle":
+                A = m.pi / 4 * (d**2)
+                I = m.pi / 64 * (d**4)
+                area.append(A)
+                area.append(area[-1])
+                second_moment_of_area.append(I)
+                second_moment_of_area.append(second_moment_of_area[-1])
+
             else:
                 # not yet supporting other kind
                 raise ValueError()
@@ -181,6 +199,8 @@ class Pile:
                 "Wall thickness [m]": thickness,
                 "Area [m2]": area,
                 "I [m4]": second_moment_of_area,
+                # "E (kPa)": self._young_modulus,
+                # "G (kPa)": self._shear_modulus
             }
         )
 

--- a/src/openpile/core/kernel.py
+++ b/src/openpile/core/kernel.py
@@ -228,6 +228,12 @@ def elem_mechanical_stiffness_matrix(model):
                 + nu**2 * (4 * a**4 + 16 * a**2 * b**2 + 4 * b**4)
             )
             kappa = nom / denom
+                        
+        elif model.pile.kind == "Solid-Circle":
+            nom = 6 * (1 + nu)
+            denom =  7 + 12*nu + 4*(nu**2)
+            kappa = nom / denom
+
         else:
             raise ValueError("Timoshenko beams cannot be used yet for non-circular pile types")
     else:
@@ -408,12 +414,16 @@ def elem_mt_stiffness_matrix(model, u, kind):
                 + nu**2 * (4 * a**4 + 16 * a**2 * b**2 + 4 * b**4)
             )
             kappa = nom / denom
-
-            omega = E * I * kappa / (A * G * L**2)
+        
+        elif model.pile.kind == "Solid-Circle":
+            nom = 6 * (1 + nu)
+            denom =  7 + 12*nu + 4*(nu**2)
+            kappa = nom / denom
 
         else:
             raise ValueError("Timoshenko beams cannot be used yet for non-circular pile types")
-
+        
+        omega = E * I * kappa / (A * G * L**2)
         phi = (12 * omega + 1) ** 2
 
         N = 0 * L
@@ -508,12 +518,16 @@ def elem_p_delta_stiffness_matrix(model, u):
                 + nu**2 * (4 * a**4 + 16 * a**2 * b**2 + 4 * b**4)
             )
             kappa = nom / denom
-
-            omega = E * I * kappa / (A * G * L**2)
+        
+        elif model.pile.kind == "Solid-Circle":
+            nom = 6 * (1 + nu)
+            denom =  7 + 12*nu + 4*(nu**2)
+            kappa = nom / denom
 
         else:
             raise ValueError("Timoshenko beams cannot be used yet for non-circular pile types")
-
+        
+        omega = E * I * kappa / (A * G * L**2)
         phi = (12 * omega + 1) ** 2
 
         N = 0 * L

--- a/src/openpile/soilmodels.py
+++ b/src/openpile/soilmodels.py
@@ -108,6 +108,115 @@ class API_clay_axial(AxialModel):
     def Qz_spring_fct():
         pass
 
+@dataclass(config=PydanticConfigFrozen)
+class frankeRollins2013(LateralModel):
+    """A class to establish the Franke and Rollins hybrid-model for liquefied soils.
+
+    Parameters
+    ----------
+    Sr: float or list[top_value, bottom_value]
+        Residual shear strength in kPa
+    eps50: float or list[top_value, bottom_value]
+        strain at 50% failure load [-]
+    J: float
+        empirical factor varying depending on clay stiffness, varies between 0.25 and 0.50
+    stiff_clay_threshold: float # not used
+        undrained shear strength [kPa] at which stiff clay curve is computed
+    G0: float or list[top_value, bottom_value] or None # not used
+        Small-strain shear modulus [unit: kPa], by default None
+    kind: str, by default "static"
+        types of curves, can be of ("static","cyclic"). # not needed
+    p_multiplier: float or function taking the depth as argument and returns the multiplier
+        multiplier for p-values
+    y_multiplier: float or function taking the depth as argument and returns the multiplier
+        multiplier for y-values
+    extension: str, by default None
+        turn on extensions by calling them in this variable
+        for API_clay, rotational springs can be added to the model with the extension "mt_curves" # not implemented
+
+
+    See also
+    --------
+    :py:func:`openpile.utils.py_curves.frankeRollins2013`
+
+    """
+
+    #: undrained shear strength [kPa], if a variation in values, two values can be given.
+    Sr: Union[PositiveFloat, conlist(PositiveFloat, min_items=1, max_items=2)]
+    #: strain at 50% failure load [-], if a variation in values, two values can be given.
+    eps50: Union[PositiveFloat, conlist(PositiveFloat, min_items=1, max_items=2)]
+    #: types of curves, can be of ("static","cyclic")
+    kind: Literal["static", "cyclic"] = "static"
+    #: small-strain stiffness [kPa], if a variation in values, two values can be given.
+    G0: Optional[Union[PositiveFloat, conlist(PositiveFloat, min_items=1, max_items=2)]] = None
+    #: empirical factor varying depending on clay stiffness
+    J: confloat(ge=0.25, le=0.5) = 0.5
+    #: undrained shear strength [kPa] at which stiff clay curve is computed
+    stiff_clay_threshold: PositiveFloat = 96
+    #: p-multiplier
+    p_multiplier: Union[Callable[[float], float], confloat(ge=0.0)] = 1.0
+    #: y-multiplier
+    y_multiplier: Union[Callable[[float], float], confloat(gt=0.0)] = 1.0
+    #: extensions available for soil model
+    extension: Optional[Literal["mt_curves"]] = None
+
+    # define class variables needed for all soil models
+    m_multiplier = 1.0
+    t_multiplier = 1.0
+
+    def __post_init__(self):
+        # spring signature which tells that API clay only has p-y curves in normal conditions
+        # signature if e.g. of the form [p-y:True, Hb:False, m-t:False, Mb:False]
+        if self.extension == "mt_curves":
+            self.spring_signature = np.array([True, False, True, False], dtype=bool)
+        else:
+            self.spring_signature = np.array([True, False, False, False], dtype=bool)
+
+    def __str__(self):
+        return f"\tFranke and Rollins (2013) Liquefied Soil\n\tSr = {var_to_str(self.Sr)} kPa\n\teps50 = {var_to_str(self.eps50)}\n\t{self.kind} curves"
+
+    def py_spring_fct(
+        self,
+        sig: float,
+        X: float,
+        layer_height: float,
+        depth_from_top_of_layer: float,
+        D: float,
+        L: float = None,
+        below_water_table: bool = True,
+        ymax: float = 0.0,
+        output_length: int = 15,
+    ):
+        # validation
+        if depth_from_top_of_layer > layer_height:
+            raise ValueError("Spring elevation outside layer")
+
+        # define Sru
+        Sr_t, Sr_b = from_list2x_parse_top_bottom(self.Sr)
+        Sr = Sr_t + (Sr_b - Sr_t) * depth_from_top_of_layer / layer_height
+
+        # define eps50
+        eps50_t, eps50_b = from_list2x_parse_top_bottom(self.eps50)
+        eps50 = eps50_t + (eps50_b - eps50_t) * depth_from_top_of_layer / layer_height
+
+        y, p = py_curves.frankeRollins2013(
+            sig=sig,
+            X=X,
+            Sr=Sr,
+            eps50=eps50,
+            D=D,
+            J=self.J,
+            stiff_clay_threshold=self.stiff_clay_threshold,
+            kind=self.kind,
+            ymax=ymax,
+            output_length=output_length,
+        )
+
+        # parse multipliers and apply results
+        y_mult = self.y_multiplier if isinstance(self.y_multiplier, float) else self.y_multiplier(X)
+        p_mult = self.p_multiplier if isinstance(self.p_multiplier, float) else self.p_multiplier(X)
+
+        return y * y_mult, p * p_mult
 
 @dataclass(config=PydanticConfigFrozen)
 class Bothkennar_clay(LateralModel):


### PR DESCRIPTION
Added Franke and Rollins (2013) hybrid py model to account for liquefied soils. It takes residual shear strength $S_r$ as an input. There are recommended values for $S_r$ such as Seed and Harder (1990), Idriss and Boulanger (2007), or Kramer and Wang (2015). $\epsilon_{30}$ is also an input, with recommendations in Franke and Rollins (2013). 

TODO: make test examples from same paper.

Also added concrete sections and solid circle sections. Assuming poisson's ratio concrete at 0.15.

Some ideas to include are:
1. The cracked concrete EI (varying stiffness)
2. More sections, materials

